### PR TITLE
Fix Variable Cultures Causing Issues Parsing Vanilla Research Count TSV

### DIFF
--- a/patches/Nitrate/Terraria/GameContent/Creative/CreativeItemSacrificesCatalog.cs.patch
+++ b/patches/Nitrate/Terraria/GameContent/Creative/CreativeItemSacrificesCatalog.cs.patch
@@ -1,0 +1,25 @@
+--- src/Nitrate_FormatWithEditorConfig/Terraria/GameContent/Creative/CreativeItemSacrificesCatalog.cs
++++ src/Nitrate/Terraria/GameContent/Creative/CreativeItemSacrificesCatalog.cs
+@@ -1,5 +_,6 @@
+ using System;
+ using System.Collections.Generic;
++using System.Globalization;
+ using System.Text.RegularExpressions;
+ 
+ using Terraria.ID;
+@@ -25,7 +_,14 @@
+ 			if (array2.Length >= 3 && ItemID.Search.TryGetId(array2[0], out var id)) {
+ 				int value = 0;
+ 				bool flag = false;
++				
++				// NITRATE: Use InvariantCulture for ToLower to avoid issues
++				// when using languages not supported by vanilla Terraria.
++				// Some languages, for example, may lowercase 'I' (as it appears
++				// in the TSV file) to some character other than 'i' (how it
++				// appears in the switch case).
+-				string text2 = array2[1].ToLower();
++				string text2 = array2[1].ToLower(CultureInfo.InvariantCulture);
++				
+ 				switch (text2) {
+ 					case "":
+ 					case "a":

--- a/patches/Nitrate/Terraria/GameContent/Creative/CreativeItemSacrificesCatalog.cs.patch
+++ b/patches/Nitrate/Terraria/GameContent/Creative/CreativeItemSacrificesCatalog.cs.patch
@@ -7,13 +7,14 @@
  using System.Text.RegularExpressions;
  
  using Terraria.ID;
-@@ -25,7 +_,14 @@
+@@ -25,7 +_,15 @@
  			if (array2.Length >= 3 && ItemID.Search.TryGetId(array2[0], out var id)) {
  				int value = 0;
  				bool flag = false;
 +				
-+				// NITRATE: Use InvariantCulture for ToLower to avoid issues
-+				// when using languages not supported by vanilla Terraria.
++				// NITRATE(#42): Use InvariantCulture for ToLower to avoid
++				// issues when using languages not supported by vanilla
++				// Terraria.
 +				// Some languages, for example, may lowercase 'I' (as it appears
 +				// in the TSV file) to some character other than 'i' (how it
 +				// appears in the switch case).


### PR DESCRIPTION
This merge request patches a normally impossible-to-encounter bug in vanilla Terraria caused by not using an invariant culture when lowercasing keys from the vanilla research count TSV. In the event the game is using a culture outside the standard set of 7 provided by vanilla (such as when using a custom language provided by Nitrate), characters may be mismatched and cause misses or exceptions.